### PR TITLE
Localize stage size screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/isoffice/posimap/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/isoffice/posimap/App.kt
@@ -39,6 +39,6 @@ private fun StageSizeResult(stage: Pair<Float, Float>) {
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Text("Stage Size: ${stage.first}m x ${stage.second}m")
+        Text("舞台サイズ：${stage.first}m × ${stage.second}m")
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/isoffice/posimap/StageSizeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/isoffice/posimap/StageSizeScreen.kt
@@ -31,13 +31,13 @@ fun StageSizeScreen(onStart: (Float, Float) -> Unit) {
         OutlinedTextField(
             value = widthInput,
             onValueChange = { widthInput = it },
-            label = { Text("Stage Width (m)") },
+            label = { Text("舞台の幅 (m)") },
             singleLine = true
         )
         OutlinedTextField(
             value = depthInput,
             onValueChange = { depthInput = it },
-            label = { Text("Stage Depth (m)") },
+            label = { Text("舞台の奥行 (m)") },
             singleLine = true
         )
         Button(
@@ -47,7 +47,7 @@ fun StageSizeScreen(onStart: (Float, Float) -> Unit) {
                 onStart(width, depth)
             }
         ) {
-            Text("Start")
+            Text("設定する")
         }
     }
 }


### PR DESCRIPTION
## Summary
- Translate stage size input labels and button text to Japanese.
- Update stage size result message to Japanese wording.

## Testing
- `./gradlew :composeApp:build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891b30fa1508322aea9c55b882f1387