### PR TITLE
Add performance name input for stage size screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/isoffice/posimap/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/isoffice/posimap/App.kt
@@ -19,19 +19,19 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 @Preview
 fun App() {
     MaterialTheme {
-        var stageSize by remember { mutableStateOf<Pair<Float, Float>?>(null) }
-        if (stageSize == null) {
-            StageSizeScreen { width, depth ->
-                stageSize = width to depth
+        var stageInfo by remember { mutableStateOf<StageInfo?>(null) }
+        if (stageInfo == null) {
+            StageSizeScreen { title, width, depth ->
+                stageInfo = StageInfo(title, width, depth)
             }
         } else {
-            StageSizeResult(stageSize!!)
+            StageSizeResult(stageInfo!!)
         }
     }
 }
 
 @Composable
-private fun StageSizeResult(stage: Pair<Float, Float>) {
+private fun StageSizeResult(stage: StageInfo) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -39,6 +39,12 @@ private fun StageSizeResult(stage: Pair<Float, Float>) {
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Text("Stage Size: ${stage.first}m x ${stage.second}m")
+        Text("『${stage.title}』の舞台サイズ：${stage.width}m × ${stage.depth}m")
     }
 }
+
+private data class StageInfo(
+    val title: String,
+    val width: Float,
+    val depth: Float,
+)

--- a/composeApp/src/commonMain/kotlin/com/isoffice/posimap/StageSizeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/isoffice/posimap/StageSizeScreen.kt
@@ -17,7 +17,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun StageSizeScreen(onStart: (Float, Float) -> Unit) {
+fun StageSizeScreen(onStart: (String, Float, Float) -> Unit) {
+    var titleInput by remember { mutableStateOf("") }
     var widthInput by remember { mutableStateOf("") }
     var depthInput by remember { mutableStateOf("") }
 
@@ -29,25 +30,31 @@ fun StageSizeScreen(onStart: (Float, Float) -> Unit) {
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         OutlinedTextField(
+            value = titleInput,
+            onValueChange = { titleInput = it },
+            label = { Text("演目名") },
+            singleLine = true
+        )
+        OutlinedTextField(
             value = widthInput,
             onValueChange = { widthInput = it },
-            label = { Text("Stage Width (m)") },
+            label = { Text("舞台の幅 (m)") },
             singleLine = true
         )
         OutlinedTextField(
             value = depthInput,
             onValueChange = { depthInput = it },
-            label = { Text("Stage Depth (m)") },
+            label = { Text("舞台の奥行 (m)") },
             singleLine = true
         )
         Button(
             onClick = {
                 val width = widthInput.toFloatOrNull() ?: 0f
                 val depth = depthInput.toFloatOrNull() ?: 0f
-                onStart(width, depth)
+                onStart(titleInput, width, depth)
             }
         ) {
-            Text("Start")
+            Text("設定する")
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow entering performance title along with stage dimensions
- display performance title in stage size result

## Testing
- `./gradlew :composeApp:build` *(fails: SDK location not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6891b30fa1508322aea9c55b882f1387