### PR TITLE
Implement basic formation editor with draggable members

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/isoffice/posimap/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/isoffice/posimap/App.kt
@@ -1,44 +1,24 @@
 package com.isoffice.posimap
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.safeContentPadding
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import com.isoffice.posimap.model.StageInfo
 
 @Composable
 @Preview
 fun App() {
     MaterialTheme {
-        var stageSize by remember { mutableStateOf<Pair<Float, Float>?>(null) }
-        if (stageSize == null) {
-            StageSizeScreen { width, depth ->
-                stageSize = width to depth
-            }
+        var stageInfo by remember { mutableStateOf<StageInfo?>(null) }
+        if (stageInfo == null) {
+            StageSizeScreen { info -> stageInfo = info }
         } else {
-            StageSizeResult(stageSize!!)
+            FormationScreen(stageInfo!!)
         }
     }
 }
 
-@Composable
-private fun StageSizeResult(stage: Pair<Float, Float>) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .safeContentPadding(),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text("Stage Size: ${stage.first}m x ${stage.second}m")
-    }
-}

--- a/composeApp/src/commonMain/kotlin/com/isoffice/posimap/FormationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/isoffice/posimap/FormationScreen.kt
@@ -1,0 +1,213 @@
+package com.isoffice.posimap
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.consumeAllChanges
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.platform.LocalDensity
+import com.isoffice.posimap.model.Member
+import com.isoffice.posimap.model.StageInfo
+import java.util.UUID
+
+@Composable
+fun FormationScreen(stage: StageInfo) {
+    val members = remember { mutableStateListOf<Member>() }
+    var showDialog by remember { mutableStateOf(false) }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        StageView(stage, members)
+
+        FloatingActionButton(
+            onClick = { if (members.size < 15) showDialog = true },
+            modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp)
+        ) {
+            Text("+")
+        }
+    }
+
+    if (showDialog) {
+        MemberDialog(
+            onAdd = { name, displayChar, color ->
+                members.add(
+                    Member(
+                        id = UUID.randomUUID().toString(),
+                        name = name,
+                        displayChar = displayChar,
+                        color = color,
+                        x = stage.width / 2f,
+                        y = stage.depth / 2f
+                    )
+                )
+                showDialog = false
+            },
+            onDismiss = { showDialog = false }
+        )
+    }
+}
+
+@Composable
+private fun StageView(stage: StageInfo, members: List<Member>) {
+    BoxWithConstraints(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        val width = maxWidth
+        val height = maxHeight
+        val scaleX = width / stage.width
+        val scaleY = height / stage.depth
+        val density = LocalDensity.current
+        val scaleXPx = with(density) { scaleX.toPx() }
+        val scaleYPx = with(density) { scaleY.toPx() }
+
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            drawRect(Color.White, size = size)
+            val centerX = size.width / 2f
+            val centerY = size.height / 2f
+            val stepX = 0.9f * scaleXPx
+            var x = centerX
+            while (x <= size.width) {
+                drawLine(Color.LightGray, Offset(x, 0f), Offset(x, size.height))
+                x += stepX
+            }
+            x = centerX - stepX
+            while (x >= 0f) {
+                drawLine(Color.LightGray, Offset(x, 0f), Offset(x, size.height))
+                x -= stepX
+            }
+            val stepY = 0.9f * scaleYPx
+            var y = centerY
+            while (y <= size.height) {
+                drawLine(Color.LightGray, Offset(0f, y), Offset(size.width, y))
+                y += stepY
+            }
+            y = centerY - stepY
+            while (y >= 0f) {
+                drawLine(Color.LightGray, Offset(0f, y), Offset(size.width, y))
+                y -= stepY
+            }
+        }
+
+        members.forEach { member ->
+            MemberItem(member, scaleX, scaleY, scaleXPx, scaleYPx, stage)
+        }
+    }
+}
+
+@Composable
+private fun MemberItem(
+    member: Member,
+    scaleX: Dp,
+    scaleY: Dp,
+    scaleXPx: Float,
+    scaleYPx: Float,
+    stage: StageInfo
+) {
+    var x by remember { mutableStateOf(member.x) }
+    var y by remember { mutableStateOf(member.y) }
+    Box(
+        modifier = Modifier
+            .offset(x * scaleX, y * scaleY)
+            .size(32.dp)
+            .background(member.color, CircleShape)
+            .pointerInput(scaleXPx, scaleYPx) {
+                detectDragGestures { change, dragAmount ->
+                    change.consumeAllChanges()
+                    x = (x + dragAmount.x / scaleXPx).coerceIn(0f, stage.width)
+                    y = (y + dragAmount.y / scaleYPx).coerceIn(0f, stage.depth)
+                    member.x = x
+                    member.y = y
+                }
+            },
+        contentAlignment = Alignment.Center
+    ) {
+        Text(member.displayChar, color = Color.White)
+    }
+}
+
+@Composable
+private fun MemberDialog(
+    onAdd: (String, String, Color) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var name by remember { mutableStateOf("") }
+    var display by remember { mutableStateOf("") }
+    var selectedColor by remember { mutableStateOf<Color?>(null) }
+    val colors = listOf(
+        Color.Red,
+        Color.Green,
+        Color.Blue,
+        Color.Yellow,
+        Color.Cyan,
+        Color.Magenta,
+        Color.Gray,
+        Color.Black,
+        Color.White,
+        Color(0xFFFFA500), // Orange
+        Color(0xFF800080), // Purple
+        Color(0xFF00FFFF)  // Aqua
+    )
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("メンバー追加") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("名前") }
+                )
+                OutlinedTextField(
+                    value = display,
+                    onValueChange = { display = it },
+                    label = { Text("表示文字") },
+                    singleLine = true
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    colors.forEach { c ->
+                        Box(
+                            modifier = Modifier
+                                .size(24.dp)
+                                .background(c)
+                                .border(
+                                    width = if (selectedColor == c) 2.dp else 1.dp,
+                                    color = Color.Black
+                                )
+                                .clickable { selectedColor = c }
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    val color = selectedColor ?: Color.Gray
+                    val disp = if (display.isNotBlank()) display else name.take(1)
+                    onAdd(name, disp, color)
+                }
+            ) {
+                Text("追加")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("キャンセル") }
+        }
+    )
+}
+

--- a/composeApp/src/commonMain/kotlin/com/isoffice/posimap/StageSizeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/isoffice/posimap/StageSizeScreen.kt
@@ -15,9 +15,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.isoffice.posimap.model.StageInfo
 
 @Composable
-fun StageSizeScreen(onStart: (Float, Float) -> Unit) {
+fun StageSizeScreen(onStart: (StageInfo) -> Unit) {
+    var titleInput by remember { mutableStateOf("") }
     var widthInput by remember { mutableStateOf("") }
     var depthInput by remember { mutableStateOf("") }
 
@@ -29,25 +31,31 @@ fun StageSizeScreen(onStart: (Float, Float) -> Unit) {
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         OutlinedTextField(
+            value = titleInput,
+            onValueChange = { titleInput = it },
+            label = { Text("演目名") },
+            singleLine = true
+        )
+        OutlinedTextField(
             value = widthInput,
             onValueChange = { widthInput = it },
-            label = { Text("Stage Width (m)") },
+            label = { Text("舞台の幅 (m)") },
             singleLine = true
         )
         OutlinedTextField(
             value = depthInput,
             onValueChange = { depthInput = it },
-            label = { Text("Stage Depth (m)") },
+            label = { Text("舞台の奥行 (m)") },
             singleLine = true
         )
         Button(
             onClick = {
                 val width = widthInput.toFloatOrNull() ?: 0f
                 val depth = depthInput.toFloatOrNull() ?: 0f
-                onStart(width, depth)
+                onStart(StageInfo(titleInput, width, depth))
             }
         ) {
-            Text("Start")
+            Text("設定する")
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/isoffice/posimap/model/StageModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/isoffice/posimap/model/StageModels.kt
@@ -1,0 +1,21 @@
+package com.isoffice.posimap.model
+
+import androidx.compose.ui.graphics.Color
+
+/** Stage information such as title and dimensions in meters. */
+data class StageInfo(
+    val title: String,
+    val width: Float,
+    val depth: Float,
+)
+
+/** Member placed on stage. Position is measured in meters from the stage left (x) and front (y). */
+data class Member(
+    val id: String,
+    val name: String,
+    val displayChar: String,
+    val color: Color,
+    var x: Float,
+    var y: Float,
+)
+


### PR DESCRIPTION
## Summary
- model stage and members with shared data classes
- accept stage size input as StageInfo and launch formation editor
- add FormationScreen with 90cm grid and draggable, color-coded members

## Testing
- `./gradlew :composeApp:build` *(fails: SDK location not found)*
- `sudo apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6891b30fa1508322aea9c55b882f1387