### PR TITLE
Fix Dp multiplication for member offset

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/isoffice/posimap/FormationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/isoffice/posimap/FormationScreen.kt
@@ -121,7 +121,11 @@ private fun MemberItem(
     var y by remember { mutableStateOf(member.y) }
     Box(
         modifier = Modifier
-            .offset(x * scaleX, y * scaleY)
+            // scaleX and scaleY represent the dp size of one meter on the stage.
+            // Multiply them on the left side so the operator extension on Dp is used
+            // (Dp * Float -> Dp). This converts the member's position in meters to
+            // device independent pixels for the offset modifier.
+            .offset(scaleX * x, scaleY * y)
             .size(32.dp)
             .background(member.color, CircleShape)
             .pointerInput(scaleXPx, scaleYPx) {


### PR DESCRIPTION
## Summary
- fix `Modifier.offset` in `MemberItem` to multiply Dp by Float, preventing type mismatch
- clarify math with inline comments

## Testing
- `./gradlew build` *(fails: SDK location not found)*
- `./gradlew composeApp:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891bc0bcbb88322be20bd8670602c67