### PR TITLE
Add Japanese comments to code

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/isoffice/posimap/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/isoffice/posimap/MainActivity.kt
@@ -9,10 +9,12 @@ import androidx.compose.ui.tooling.preview.Preview
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        // システムUIのレイアウトを端まで広げる
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         setContent {
+            // Composeアプリのエントリーポイント
             App()
         }
     }
@@ -21,5 +23,6 @@ class MainActivity : ComponentActivity() {
 @Preview
 @Composable
 fun AppAndroidPreview() {
+    // Android Studio用のプレビュー
     App()
 }

--- a/composeApp/src/androidMain/kotlin/com/isoffice/posimap/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/isoffice/posimap/Platform.android.kt
@@ -2,8 +2,10 @@ package com.isoffice.posimap
 
 import android.os.Build
 
+// Android向けのPlatform実装
 class AndroidPlatform : Platform {
     override val name: String = "Android ${Build.VERSION.SDK_INT}"
 }
 
+// Androidで実行中のPlatformを返す
 actual fun getPlatform(): Platform = AndroidPlatform()

--- a/composeApp/src/commonMain/kotlin/com/isoffice/posimap/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/isoffice/posimap/App.kt
@@ -9,14 +9,19 @@ import androidx.compose.runtime.setValue
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import com.isoffice.posimap.model.StageInfo
 
+/** アプリ全体のエントリーポイント */
 @Composable
 @Preview
 fun App() {
+    // Material3のテーマを適用したルートコンポーネント
     MaterialTheme {
+        // 舞台情報を保持するステート。nullの場合は未設定
         var stageInfo by remember { mutableStateOf<StageInfo?>(null) }
         if (stageInfo == null) {
-           StageSizeScreen { info -> stageInfo = info }
+            // 舞台サイズ入力画面を表示し、確定したら情報をステートに保存
+            StageSizeScreen { info -> stageInfo = info }
         } else {
+            // 舞台情報がある場合はフォーメーション編集画面を表示
             FormationScreen(stageInfo!!)
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/isoffice/posimap/FormationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/isoffice/posimap/FormationScreen.kt
@@ -29,25 +29,34 @@ import com.isoffice.posimap.model.StageInfo
 import kotlin.math.min
 import kotlin.random.Random
 
+/** フォーメーションを編集する画面 */
 @Composable
 fun FormationScreen(stage: StageInfo) {
+    // 編集対象となるメンバー一覧
     val members = remember { mutableStateListOf<Member>() }
+    // シーンごとのフォーメーション情報
     val scenes = remember {
         mutableStateListOf(
             Scene(Random.nextLong().toString(), "", mutableMapOf())
         )
     }
+    // 現在選択されているシーンのインデックス
     var currentSceneIndex by remember { mutableStateOf(0) }
+    // メンバー追加ダイアログの表示フラグ
     var showDialog by remember { mutableStateOf(false) }
 
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        // 画面幅からタブレットかどうかを判定
         val isTablet = maxWidth > 600.dp
+        // メモ欄の表示状態。タブレットでは常に表示
         var memoVisible by remember { mutableStateOf(isTablet) }
 
         Column(modifier = Modifier.fillMaxSize()) {
             Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                // 舞台の描画とメンバー表示
                 StageView(stage, members, scenes[currentSceneIndex])
 
+                // メンバー追加用のFAB。最大15人まで追加可能
                 FloatingActionButton(
                     onClick = { if (members.size < 15) showDialog = true },
                     modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp)
@@ -56,6 +65,7 @@ fun FormationScreen(stage: StageInfo) {
                 }
             }
 
+            // シーンの追加や切り替えを行う操作ボタン群
             SceneControls(
                 scenes = scenes,
                 currentIndex = currentSceneIndex,
@@ -84,6 +94,7 @@ fun FormationScreen(stage: StageInfo) {
                 }
             )
 
+            // 保存・共有ボタンとメモ表示切り替え
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -103,6 +114,7 @@ fun FormationScreen(stage: StageInfo) {
                 }
             }
 
+            // メモ欄
             if (memoVisible) {
                 OutlinedTextField(
                     value = scenes[currentSceneIndex].memo,
@@ -116,8 +128,10 @@ fun FormationScreen(stage: StageInfo) {
         }
 
         if (showDialog) {
+            // メンバー追加ダイアログ
             MemberDialog(
                 onAdd = { name, displayChar, color ->
+                    // 初期位置は舞台の中央
                     val centerX = stage.width / 2f
                     val centerY = stage.depth / 2f
                     val member = Member(
@@ -141,12 +155,13 @@ fun FormationScreen(stage: StageInfo) {
 
 @Composable
 private fun StageView(stage: StageInfo, members: List<Member>, scene: Scene) {
+    // 舞台のグリッドを描画し、メンバーを配置するビュー
     BoxWithConstraints(
         modifier = Modifier
             .fillMaxSize()
             .padding(16.dp)
     ) {
-        val grid = 0.9f
+        val grid = 0.9f // 90cmグリッド
         val widthDp = maxWidth
         val heightDp = maxHeight
         val scale = min(widthDp / (stage.width + grid * 2f), heightDp / stage.depth)
@@ -165,6 +180,7 @@ private fun StageView(stage: StageInfo, members: List<Member>, scene: Scene) {
         val gridDp = scale * grid
 
         Canvas(modifier = Modifier.fillMaxSize()) {
+            // 背景とグリッド線の描画
             drawRect(
                 Color.White,
                 topLeft = Offset(offsetXPx, offsetYPx),
@@ -208,6 +224,7 @@ private fun MemberItem(
     stage: StageInfo,
     scene: Scene
 ) {
+    // シーンごとの座標を保持する
     var x by remember(scene) { mutableStateOf(member.x) }
     var y by remember(scene) { mutableStateOf(member.y) }
     Box(
@@ -217,6 +234,7 @@ private fun MemberItem(
             .background(member.color, CircleShape)
             .pointerInput(scalePx) {
                 detectDragGestures { change, dragAmount ->
+                    // ドラッグ操作でメンバーを移動
                     change.consumeAllChanges()
                     x = (x + dragAmount.x / scalePx).coerceIn(0f, stage.width)
                     y = (y + dragAmount.y / scalePx).coerceIn(0f, stage.depth)
@@ -236,8 +254,11 @@ private fun MemberDialog(
     onAdd: (String, String, Color) -> Unit,
     onDismiss: () -> Unit
 ) {
+    // 入力中のメンバー名
     var name by remember { mutableStateOf("") }
+    // 表示文字
     var display by remember { mutableStateOf("") }
+    // 選択された色
     var selectedColor by remember { mutableStateOf<Color?>(null) }
     val colors = listOf(
         Color.Red,
@@ -249,9 +270,9 @@ private fun MemberDialog(
         Color.Gray,
         Color.Black,
         Color.White,
-        Color(0xFFFFA500), // Orange
-        Color(0xFF800080), // Purple
-        Color(0xFF00FFFF)  // Aqua
+        Color(0xFFFFA500), // オレンジ
+        Color(0xFF800080), // パープル
+        Color(0xFF00FFFF)  // アクア
     )
 
     AlertDialog(
@@ -312,12 +333,14 @@ private fun SceneControls(
     onAddAfter: () -> Unit,
     onRemove: () -> Unit
 ) {
+    // シーン番号や追加・削除ボタンを表示する行
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
+        // 現在の前にシーンを追加
         Button(onClick = onAddBefore, modifier = Modifier.padding(4.dp)) { Text("＋前") }
         LazyRow(
             modifier = Modifier.weight(1f),
@@ -325,13 +348,16 @@ private fun SceneControls(
         ) {
             itemsIndexed(scenes) { index, _ ->
                 if (index == currentIndex) {
+                    // 選択中のシーン
                     Button(onClick = { onSelect(index) }) { Text((index + 1).toString()) }
                 } else {
                     OutlinedButton(onClick = { onSelect(index) }) { Text((index + 1).toString()) }
                 }
             }
         }
+        // 現在の後にシーンを追加
         Button(onClick = onAddAfter, modifier = Modifier.padding(4.dp)) { Text("＋後") }
+        // シーンを削除（最低1シーンは残す）
         Button(
             onClick = onRemove,
             enabled = scenes.size > 1,
@@ -341,6 +367,7 @@ private fun SceneControls(
 }
 
 private fun loadMembersFromScene(scene: Scene, members: List<Member>, stage: StageInfo) {
+    // シーンに保存された座標をメンバーに適用する
     members.forEach { member ->
         val pos = scene.positions[member.id] ?: (stage.width / 2f to stage.depth / 2f)
         member.x = pos.first

--- a/composeApp/src/commonMain/kotlin/com/isoffice/posimap/Greeting.kt
+++ b/composeApp/src/commonMain/kotlin/com/isoffice/posimap/Greeting.kt
@@ -1,8 +1,10 @@
 package com.isoffice.posimap
 
+// プラットフォームに依存した挨拶メッセージを生成するクラス
 class Greeting {
     private val platform = getPlatform()
 
+    // 挨拶文を返す
     fun greet(): String {
         return "Hello, ${platform.name}!"
     }

--- a/composeApp/src/commonMain/kotlin/com/isoffice/posimap/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/com/isoffice/posimap/Platform.kt
@@ -1,7 +1,9 @@
 package com.isoffice.posimap
 
+// 実行中のプラットフォーム情報を表すインターフェース
 interface Platform {
     val name: String
 }
 
+// 各プラットフォーム固有の実装を返す
 expect fun getPlatform(): Platform

--- a/composeApp/src/commonMain/kotlin/com/isoffice/posimap/StageSizeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/isoffice/posimap/StageSizeScreen.kt
@@ -17,10 +17,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.isoffice.posimap.model.StageInfo
 
+/** 舞台のサイズを入力する画面 */
 @Composable
 fun StageSizeScreen(onStart: (StageInfo) -> Unit) {
+    // ユーザーが入力した演目名
     var titleInput by remember { mutableStateOf("") }
+    // 舞台の幅(m)
     var widthInput by remember { mutableStateOf("") }
+    // 舞台の奥行(m)
     var depthInput by remember { mutableStateOf("") }
 
     Column(
@@ -30,18 +34,21 @@ fun StageSizeScreen(onStart: (StageInfo) -> Unit) {
         verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        // 演目名入力欄
         OutlinedTextField(
             value = titleInput,
             onValueChange = { titleInput = it },
             label = { Text("演目名") },
             singleLine = true
         )
+        // 舞台の幅入力欄
         OutlinedTextField(
             value = widthInput,
             onValueChange = { widthInput = it },
             label = { Text("舞台の幅 (m)") },
             singleLine = true
         )
+        // 舞台の奥行入力欄
         OutlinedTextField(
             value = depthInput,
             onValueChange = { depthInput = it },
@@ -50,9 +57,10 @@ fun StageSizeScreen(onStart: (StageInfo) -> Unit) {
         )
         Button(
             onClick = {
+                // 入力値を数値に変換しStageInfoを作成してコールバック
                 val width = widthInput.toFloatOrNull() ?: 0f
                 val depth = depthInput.toFloatOrNull() ?: 0f
-               onStart(StageInfo(titleInput, width, depth))
+                onStart(StageInfo(titleInput, width, depth))
             }
         ) {
             Text("設定する")

--- a/composeApp/src/commonMain/kotlin/com/isoffice/posimap/model/StageModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/isoffice/posimap/model/StageModels.kt
@@ -2,14 +2,14 @@ package com.isoffice.posimap.model
 
 import androidx.compose.ui.graphics.Color
 
-/** Stage information such as title and dimensions in meters. */
+/** 舞台のタイトルや寸法（メートル）を保持するデータクラス */
 data class StageInfo(
     val title: String,
     val width: Float,
     val depth: Float,
 )
 
-/** Member placed on stage. Position is measured in meters from the stage left (x) and front (y). */
+/** 舞台上に配置されたメンバー。位置は舞台左端からのxと前方からのyをメートルで表す */
 data class Member(
     val id: String,
     val name: String,
@@ -19,7 +19,7 @@ data class Member(
     var y: Float,
 )
 
-/** A formation state for a given scene. */
+/** 各シーンのフォーメーション状態を表す */
 data class Scene(
     val id: String,
     var memo: String,

--- a/composeApp/src/iosMain/kotlin/com/isoffice/posimap/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/com/isoffice/posimap/MainViewController.kt
@@ -2,4 +2,5 @@ package com.isoffice.posimap
 
 import androidx.compose.ui.window.ComposeUIViewController
 
+// iOS用のエントリーポイント
 fun MainViewController() = ComposeUIViewController { App() }

--- a/composeApp/src/iosMain/kotlin/com/isoffice/posimap/Platform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/isoffice/posimap/Platform.ios.kt
@@ -2,8 +2,10 @@ package com.isoffice.posimap
 
 import platform.UIKit.UIDevice
 
+// iOS向けのPlatform実装
 class IOSPlatform: Platform {
     override val name: String = UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
 }
 
+// iOSで実行中のPlatformを返す
 actual fun getPlatform(): Platform = IOSPlatform()

--- a/composeApp/src/wasmJsMain/kotlin/com/isoffice/posimap/Platform.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/com/isoffice/posimap/Platform.wasmJs.kt
@@ -1,7 +1,9 @@
 package com.isoffice.posimap
 
+// Kotlin/Wasm 向けのPlatform実装
 class WasmPlatform: Platform {
     override val name: String = "Web with Kotlin/Wasm"
 }
 
+// Web環境で実行中のPlatformを返す
 actual fun getPlatform(): Platform = WasmPlatform()

--- a/composeApp/src/wasmJsMain/kotlin/com/isoffice/posimap/main.kt
+++ b/composeApp/src/wasmJsMain/kotlin/com/isoffice/posimap/main.kt
@@ -6,6 +6,7 @@ import kotlinx.browser.document
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
+    // ブラウザのDOMにComposeコンテンツを描画する
     ComposeViewport(document.body!!) {
         App()
     }


### PR DESCRIPTION
## Summary
- Documented app entry point and stage setup in Japanese
- Added Japanese comments to formation editing logic
- Commented platform-specific implementations for Android/iOS/Wasm

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68929d9095948322b8bc8e4530579e88