### PR TITLE
Add first launch performance setup screen

### DIFF
--- a/androidApp/src/main/kotlin/com/isoffice/posimap/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/isoffice/posimap/android/MainActivity.kt
@@ -1,35 +1,115 @@
 package com.isoffice.posimap.android
 
+import android.content.Context
 import android.os.Bundle
+import android.view.View
+import android.widget.Button
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
-import com.isoffice.posimap.model.FormationScene
-import com.isoffice.posimap.model.Member
-import com.isoffice.posimap.model.Performance
-import com.isoffice.posimap.model.Position
-import com.isoffice.posimap.model.Stage
-import com.isoffice.posimap.repository.PerformanceRepository
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
 
 class MainActivity : AppCompatActivity() {
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
 
-        // ダミーデータ作成
-        val performance = Performance(
-            title = "Demo Performance",
-            stage = Stage(10, 5),
-            members = listOf(Member("m1", "Anne", "A", "#FF0000")),
-            scenes = listOf(
-                FormationScene(
-                    id = "scene-001",
-                    title = "Opening",
-                    positions = listOf(Position("m1", 2, 1))
-                )
-            )
-        )
+        val formContainer: View = findViewById(R.id.formContainer)
+        val summaryContainer: View = findViewById(R.id.summaryContainer)
+        val titleLayout: TextInputLayout = findViewById(R.id.performanceTitleLayout)
+        val titleInput: TextInputEditText = findViewById(R.id.performanceTitleInput)
+        val widthLayout: TextInputLayout = findViewById(R.id.stageWidthLayout)
+        val widthInput: TextInputEditText = findViewById(R.id.stageWidthInput)
+        val heightLayout: TextInputLayout = findViewById(R.id.stageHeightLayout)
+        val heightInput: TextInputEditText = findViewById(R.id.stageHeightInput)
+        val summaryTitle: TextView = findViewById(R.id.summaryTitle)
+        val summaryStage: TextView = findViewById(R.id.summaryStage)
+        val saveButton: Button = findViewById(R.id.saveButton)
+        val editButton: Button = findViewById(R.id.editButton)
 
-        // JSON共有
-        val repo = PerformanceRepository()
-        val bytes = repo.export(performance)
-        ShareGateway(this).share(bytes, "demo.posimap.json")
+        val settings = loadSettings()
+        if (settings != null) {
+            updateSummary(summaryTitle, summaryStage, settings)
+            formContainer.visibility = View.GONE
+            summaryContainer.visibility = View.VISIBLE
+        } else {
+            summaryContainer.visibility = View.GONE
+            formContainer.visibility = View.VISIBLE
+        }
+
+        saveButton.setOnClickListener {
+            titleLayout.error = null
+            widthLayout.error = null
+            heightLayout.error = null
+
+            val title = titleInput.text?.toString()?.trim().orEmpty()
+            val width = widthInput.text?.toString()?.trim()?.toIntOrNull()
+            val height = heightInput.text?.toString()?.trim()?.toIntOrNull()
+
+            var hasError = false
+            if (title.isEmpty()) {
+                titleLayout.error = getString(R.string.input_error_required)
+                hasError = true
+            }
+            if (width == null || width <= 0) {
+                widthLayout.error = getString(R.string.input_error_positive_number)
+                hasError = true
+            }
+            if (height == null || height <= 0) {
+                heightLayout.error = getString(R.string.input_error_positive_number)
+                hasError = true
+            }
+
+            if (!hasError) {
+                val newSettings = PerformanceSettings(title, width!!, height!!)
+                saveSettings(newSettings)
+                updateSummary(summaryTitle, summaryStage, newSettings)
+                formContainer.visibility = View.GONE
+                summaryContainer.visibility = View.VISIBLE
+            }
+        }
+
+        editButton.setOnClickListener {
+            val current = loadSettings()
+            if (current != null) {
+                titleInput.setText(current.title)
+                widthInput.setText(current.stageWidth.toString())
+                heightInput.setText(current.stageHeight.toString())
+            }
+            summaryContainer.visibility = View.GONE
+            formContainer.visibility = View.VISIBLE
+        }
+    }
+
+    private fun loadSettings(): PerformanceSettings? {
+        val prefs = getPreferences(Context.MODE_PRIVATE)
+        val title = prefs.getString(KEY_TITLE, null) ?: return null
+        val width = prefs.getInt(KEY_STAGE_WIDTH, -1)
+        val height = prefs.getInt(KEY_STAGE_HEIGHT, -1)
+        if (width <= 0 || height <= 0) return null
+        return PerformanceSettings(title, width, height)
+    }
+
+    private fun saveSettings(settings: PerformanceSettings) {
+        val prefs = getPreferences(Context.MODE_PRIVATE)
+        prefs.edit()
+            .putString(KEY_TITLE, settings.title)
+            .putInt(KEY_STAGE_WIDTH, settings.stageWidth)
+            .putInt(KEY_STAGE_HEIGHT, settings.stageHeight)
+            .apply()
+    }
+
+    private fun updateSummary(titleView: TextView, stageView: TextView, settings: PerformanceSettings) {
+        titleView.text = getString(R.string.summary_title_format, settings.title)
+        stageView.text = getString(R.string.summary_stage_format, settings.stageWidth, settings.stageHeight)
+    }
+
+    private data class PerformanceSettings(val title: String, val stageWidth: Int, val stageHeight: Int)
+
+    companion object {
+        private const val KEY_TITLE = "performance_title"
+        private const val KEY_STAGE_WIDTH = "stage_width"
+        private const val KEY_STAGE_HEIGHT = "stage_height"
     }
 }

--- a/androidApp/src/main/res/layout/activity_main.xml
+++ b/androidApp/src/main/res/layout/activity_main.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="24dp">
+
+        <LinearLayout
+            android:id="@+id/formContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingBottom="8dp"
+                android:text="@string/performance_setup_title"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Headline6" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingBottom="24dp"
+                android:text="@string/performance_setup_description"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/performanceTitleLayout"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/performance_title_label"
+                android:paddingBottom="16dp"
+                app:endIconMode="clear_text">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/performanceTitleInput"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:imeOptions="actionNext"
+                    android:inputType="textCapSentences" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/stageWidthLayout"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/stage_width_label"
+                android:paddingBottom="16dp">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/stageWidthInput"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:imeOptions="actionNext"
+                    android:inputType="number" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/stageHeightLayout"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/stage_height_label"
+                android:paddingBottom="24dp">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/stageHeightInput"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:imeOptions="actionDone"
+                    android:inputType="number" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <Button
+                android:id="@+id/saveButton"
+                style="@style/Widget.MaterialComponents.Button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/setup_submit" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/summaryContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <TextView
+                android:id="@+id/summaryTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingBottom="8dp"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1" />
+
+            <TextView
+                android:id="@+id/summaryStage"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingBottom="16dp"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
+
+            <Button
+                android:id="@+id/editButton"
+                style="@style/Widget.MaterialComponents.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/edit_button" />
+        </LinearLayout>
+
+    </LinearLayout>
+</ScrollView>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">立ち位置くん</string>
+    <string name="performance_setup_title">演目の設定</string>
+    <string name="performance_setup_description">最初に演目名と舞台のサイズを入力してください。</string>
+    <string name="performance_title_label">演目名</string>
+    <string name="stage_width_label">舞台の幅</string>
+    <string name="stage_height_label">舞台の奥行き</string>
+    <string name="setup_submit">決定</string>
+    <string name="summary_title_format">演目名: %1$s</string>
+    <string name="summary_stage_format">舞台サイズ: 幅%1$d × 奥行き%2$d</string>
+    <string name="edit_button">編集</string>
+    <string name="input_error_required">必須項目です</string>
+    <string name="input_error_positive_number">1以上の数値を入力してください</string>
+</resources>


### PR DESCRIPTION
## Summary
- add a first-launch setup flow to collect the performance title and stage dimensions
- persist the setup values and show an editable summary once registration is complete
- introduce the supporting layout and string resources for the new screen

## Testing
- `./gradlew :androidApp:lint` *(fails: plugin org.jetbrains.kotlin.multiplatform:2.0.20 cannot be resolved in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d11aae7f948322b05539d1ca48286c